### PR TITLE
INNER JOIN when selecting files and torrents to avoid null results

### DIFF
--- a/src/addon/src/lib/repository.js
+++ b/src/addon/src/lib/repository.js
@@ -99,7 +99,7 @@ export function getImdbIdSeriesEntries(imdbId, season, episode) {
             imdbSeason: { [Op.eq]: season },
             imdbEpisode: { [Op.eq]: episode }
         },
-        include: [Torrent],
+        include: { model: Torrent, required: true },
         limit: 500,
         order: [
             [Torrent, 'size', 'DESC']
@@ -112,7 +112,7 @@ export function getKitsuIdMovieEntries(kitsuId) {
         where: {
             kitsuId: { [Op.eq]: kitsuId }
         },
-        include: [Torrent],
+        include: { model: Torrent, required: true },
         limit: 500,
         order: [
             [Torrent, 'size', 'DESC']
@@ -126,7 +126,7 @@ export function getKitsuIdSeriesEntries(kitsuId, episode) {
             kitsuId: { [Op.eq]: kitsuId },
             kitsuEpisode: { [Op.eq]: episode }
         },
-        include: [Torrent],
+        include: { model: Torrent, required: true },
         limit: 500,
         order: [
             [Torrent, 'size', 'DESC']

--- a/src/addon/src/lib/repository.js
+++ b/src/addon/src/lib/repository.js
@@ -84,7 +84,7 @@ export function getImdbIdMovieEntries(imdbId) {
         where: {
             imdbId: { [Op.eq]: imdbId }
         },
-        include: [Torrent],
+        include: { model: Torrent, required: true },
         limit: 500,
         order: [
             [Torrent, 'size', 'DESC']


### PR DESCRIPTION
After recent parser changes (which presumably discard some torrents *after* files end up in the files table), I found my addon erroring on certain IMDB queries.

It turns out the sequelize query which assembles the stream results performs a `LEFT OUTER JOIN` between the files table and the torrents table. Consequently, if theres' an infoHash in the files table which doesn't exist in the torrents table, the query will return `NULL` for all of the torrent fields, including `seeders`, `title`, etc.

I'm not sure why this happened, but it seems safer to use an `INNER JOIN`, such that only data which exists in both the files and torrents table is returned.

This PR simply effects this change, such that null results are no longer returned, and the addon doesn't error.