### PR TITLE
Always return title and filename

### DIFF
--- a/src/addon/src/lib/streamInfo.js
+++ b/src/addon/src/lib/streamInfo.js
@@ -20,7 +20,7 @@ export function toStreamInfo(record) {
   const title = joinDetailParts(
       [
         joinDetailParts([record.torrent.title.replace(/[, ]+/g, ' ')]),
-        joinDetailParts([!sameInfo && record.title || undefined]),
+        joinDetailParts([record.title || undefined]),
         joinDetailParts([
           joinDetailParts([formatSize(record.size)], '💾 ')
         ]),


### PR DESCRIPTION
Another minor UX fix here.. the original addon included code to avoid returning both `file.title` and `torrent.title` - if `file.title` included the contents of `torrent.title`, then only `torrent.title` will be returned.


Since we're now parsing titles better, most of the time `torrent.title` is a nice, friendly movie/series name.

This means that if `torrent.title` is `Fallout`, and `file.title` is 
`Fallout.2024.S01E01.MULTi.VF2.HDR.2160p.WEB.H265-FW.mkv`, the addon will only return `Fallout`.

The disadvantages here are:

1. The user can no longer parse the file details to make a decision about which stream to pick (based on audio codec for example)
2. Automation which uses the addon (the Prowlarr indexer, for example) don't return valid results (*these often split the results by predictable fields, such as `\n`*)

This PR simply ensures that the returned title data is predictable, like this:

```json
      "name": "[RD+] knightcrawler\n4k HDR",
      "title": "Fallout\nFallout.2024.S01E01.MULTi.VF2.HDR.2160p.WEB.H265-FW.mkv\n💾 10.62 GB\nMulti Audio",
      "url": "http://localhost:7000/realdebrid/<api key>/d0fa7ebba43072b8a878a6791d5cbe4b7a88a62e/null/1/Multi%20Audio",
      "behaviorHints": {
        "bingeGroup": "knightcrawler|4k|HDR|FW"
      }

```


