### PR TITLE
Update all-debrid-api to v1.2.0 for new IP requirement

### DIFF
--- a/src/addon/package-lock.json
+++ b/src/addon/package-lock.json
@@ -12,7 +12,7 @@
         "@redis/client": "^1.5.14",
         "@redis/json": "^1.0.6",
         "@redis/search": "^1.1.6",
-        "all-debrid-api": "^1.1.0",
+        "all-debrid-api": "^1.2.0",
         "axios": "^1.6.1",
         "bottleneck": "^2.19.5",
         "cache-manager": "^3.4.4",

--- a/src/addon/package.json
+++ b/src/addon/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@putdotio/api-client": "^8.42.0",
-    "all-debrid-api": "^1.1.0",
+    "all-debrid-api": "^1.2.0",
     "axios": "^1.6.1",
     "bottleneck": "^2.19.5",
     "cache-manager": "^3.4.4",


### PR DESCRIPTION
Hey folks,

I'm a total nodejs noob, so LMK if this is not the right way to do this.. this PR simply updates the minimum required version of `all-debrid-api` to v1.2.0, which incorporades the `ip` query string in the URL, which will become an [alldebrid requirement](https://cdn.discordapp.com/attachments/701542427059814461/1233303462155128914/tempFileForShare_20240426-092648.jpg?ex=662f3ddb&is=662dec5b&hm=d0ae2cf27910915dce2c54b1ab63434d519788bb19f2908d1a17a78dcf939e2d&) in the next few weeks.

