### PR TITLE
Re-add filter step in the processing of the streams

### DIFF
--- a/src/addon/src/addon.js
+++ b/src/addon/src/addon.js
@@ -3,6 +3,7 @@ import { addonBuilder } from 'stremio-addon-sdk';
 import { cacheWrapStream } from './lib/cache.js';
 import { dummyManifest } from './lib/manifest.js';
 import * as repository from './lib/repository.js';
+import applyFilters from "./lib/filter.js";
 import applySorting from './lib/sort.js';
 import { toStreamInfo, applyStaticInfo } from './lib/streamInfo.js';
 import { Type } from './lib/types.js';
@@ -32,6 +33,7 @@ builder.defineStreamHandler((args) => {
       .then(records => records
           .sort((a, b) => b.torrent.seeders - a.torrent.seeders || b.torrent.uploadDate - a.torrent.uploadDate)
           .map(record => toStreamInfo(record)))))
+      .then(streams => applyFilters(streams, args.extra))
       .then(streams => applySorting(streams, args.extra))
       .then(streams => applyStaticInfo(streams))
       .then(streams => applyMochs(streams, args.extra))


### PR DESCRIPTION
Filters have been removed in the following commit: https://github.com/knightcrawler-stremio/knightcrawler/commit/ab17ef81be610005049d6ccc8c2a1417d18626b2#diff-748ff5015b225e4bd801eb1c6b5c60d239f46d8a96f85e24acc83b7ade8dadddL30
This commit re-adds them, so the user can filter by quality and size.

I haven't tested it yet, because i don't have a setup with enough torrents to test it.