### PR TITLE
Fix DMM parser and a couple of other minor issues.

### DIFF
--- a/src/debrid-collector/Dockerfile
+++ b/src/debrid-collector/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 
 ENV PYTHONUNBUFFERED=1
 
-RUN apk add --update --no-cache python3=~3.11.9-r0 py3-pip && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3=~3.11 py3-pip && ln -sf python3 /usr/bin/python
 
 COPY --from=build /src/out .
 

--- a/src/metadata/Features/Configuration/PostgresConfiguration.cs
+++ b/src/metadata/Features/Configuration/PostgresConfiguration.cs
@@ -8,12 +8,14 @@ public class PostgresConfiguration
     private const string PasswordVariable = "PASSWORD";
     private const string DatabaseVariable = "DB";
     private const string PortVariable = "PORT";
+    private const string CommandTimeoutVariable = "COMMAND_TIMEOUT_SEC"; // Seconds
 
     private string Host { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(HostVariable);
     private string Username { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(UsernameVariable);
     private string Password { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(PasswordVariable);
     private string Database { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(DatabaseVariable);
     private int PORT { get; init; } = Prefix.GetEnvironmentVariableAsInt(PortVariable, 5432);
+    private int CommandTimeout { get; init; } = Prefix.GetEnvironmentVariableAsInt(CommandTimeoutVariable, 300);
 
-    public string StorageConnectionString => $"Host={Host};Port={PORT};Username={Username};Password={Password};Database={Database};";
+    public string StorageConnectionString => $"Host={Host};Port={PORT};Username={Username};Password={Password};Database={Database};CommandTimeout={CommandTimeout}";
 }

--- a/src/metadata/Features/ImportImdbData/ImdbDbService.cs
+++ b/src/metadata/Features/ImportImdbData/ImdbDbService.cs
@@ -134,7 +134,7 @@ public class ImdbDbService(PostgresConfiguration configuration, ILogger<ImdbDbSe
     {
         try
         {
-            await using var connection = CreateNpgsqlConnection();
+            await using var connection = new NpgsqlConnection(configuration.StorageConnectionString);
             await connection.OpenAsync();
 
             await operation(connection);
@@ -143,16 +143,6 @@ public class ImdbDbService(PostgresConfiguration configuration, ILogger<ImdbDbSe
         {
             logger.LogError(e, errorMessage);
         }
-    }
-
-    private NpgsqlConnection CreateNpgsqlConnection()
-    {
-        var connectionStringBuilder = new NpgsqlConnectionStringBuilder(configuration.StorageConnectionString)
-        {
-            CommandTimeout = 3000,
-        };
-
-        return new(connectionStringBuilder.ConnectionString);
     }
 
     private async Task ExecuteCommandWithTransactionAsync(Func<NpgsqlConnection, NpgsqlTransaction, Task> operation, NpgsqlTransaction transaction, string errorMessage)

--- a/src/metadata/Metadata.csproj
+++ b/src/metadata/Metadata.csproj
@@ -13,7 +13,7 @@
       <PackageReference Include="Dapper" Version="2.1.35" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-      <PackageReference Include="Npgsql" Version="8.0.2" />
+      <PackageReference Include="Npgsql" Version="8.0.3" />
       <PackageReference Include="Serilog" Version="3.1.1" />
       <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
       <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />

--- a/src/producer/src/Dockerfile
+++ b/src/producer/src/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 
 ENV PYTHONUNBUFFERED=1
 
-RUN apk add --update --no-cache python3=~3.11.9-r0 py3-pip && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3=~3.11 py3-pip && ln -sf python3 /usr/bin/python
 
 COPY --from=build /src/out .
 

--- a/src/qbit-collector/Dockerfile
+++ b/src/qbit-collector/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 
 ENV PYTHONUNBUFFERED=1
 
-RUN apk add --update --no-cache python3=~3.11.9-r0 py3-pip && ln -sf python3 /usr/bin/python
+RUN apk add --update --no-cache python3=~3.11 py3-pip && ln -sf python3 /usr/bin/python
 
 COPY --from=build /src/out .
 

--- a/src/shared/Configuration/PostgresConfiguration.cs
+++ b/src/shared/Configuration/PostgresConfiguration.cs
@@ -8,12 +8,14 @@ public class PostgresConfiguration
     private const string PasswordVariable = "PASSWORD";
     private const string DatabaseVariable = "DB";
     private const string PortVariable = "PORT";
+    private const string CommandTimeoutVariable = "COMMAND_TIMEOUT_SEC"; // Seconds
 
     private string Host { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(HostVariable);
     private string Username { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(UsernameVariable);
     private string Password { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(PasswordVariable);
     private string Database { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(DatabaseVariable);
     private int PORT { get; init; } = Prefix.GetEnvironmentVariableAsInt(PortVariable, 5432);
+    private int CommandTimeout { get; init; } = Prefix.GetEnvironmentVariableAsInt(CommandTimeoutVariable, 300);
 
-    public string StorageConnectionString => $"Host={Host};Port={PORT};Username={Username};Password={Password};Database={Database};";
+    public string StorageConnectionString => $"Host={Host};Port={PORT};Username={Username};Password={Password};Database={Database};CommandTimeout={CommandTimeout}";
 }

--- a/src/shared/SharedContracts.csproj
+++ b/src/shared/SharedContracts.csproj
@@ -15,7 +15,7 @@
   <PackageReference Include="Dapper" Version="2.1.35" />
   <PackageReference Include="MassTransit.Abstractions" Version="8.2.0" />
   <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.0" />
-  <PackageReference Include="Npgsql" Version="8.0.2" />
+  <PackageReference Include="Npgsql" Version="8.0.3" />
   <PackageReference Include="pythonnet" Version="3.0.3" />
   <PackageReference Include="Serilog" Version="3.1.1" />
   <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />

--- a/src/tissue/Features/DataProcessing/PostgresConfiguration.cs
+++ b/src/tissue/Features/DataProcessing/PostgresConfiguration.cs
@@ -8,12 +8,14 @@ public class PostgresConfiguration
     private const string PasswordVariable = "PASSWORD";
     private const string DatabaseVariable = "DB";
     private const string PortVariable = "PORT";
+    private const string CommandTimeoutVariable = "COMMAND_TIMEOUT_SEC"; // Seconds
 
     private string Host { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(HostVariable);
     private string Username { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(UsernameVariable);
     private string Password { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(PasswordVariable);
     private string Database { get; init; } = Prefix.GetRequiredEnvironmentVariableAsString(DatabaseVariable);
     private int PORT { get; init; } = Prefix.GetEnvironmentVariableAsInt(PortVariable, 5432);
+    private int CommandTimeout { get; init; } = Prefix.GetEnvironmentVariableAsInt(CommandTimeoutVariable, 300);
 
-    public string StorageConnectionString => $"Host={Host};Port={PORT};Username={Username};Password={Password};Database={Database};";
+    public string StorageConnectionString => $"Host={Host};Port={PORT};Username={Username};Password={Password};Database={Database};CommandTimeout={CommandTimeout}";
 }

--- a/src/tissue/Tissue.csproj
+++ b/src/tissue/Tissue.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="Dapper" Version="2.1.28" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-      <PackageReference Include="Npgsql" Version="8.0.1" />
+      <PackageReference Include="Npgsql" Version="8.0.3" />
       <PackageReference Include="Serilog" Version="3.1.1" />
       <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
       <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />


### PR DESCRIPTION
* Parse new types of JSON encountered in the DMM URLs
* Remove python version requirement in the Dockerfile because the version requested isn't available any more.
* Sets all SQL command timeouts to 50 minutes following the suite of one existing call in the codebase. I experienced some timeouts on my i5 7500T machine without this change.
* Bumps patch version of pgsql connection library because of a severe CVE in 8.0.2 according to the build scripts.